### PR TITLE
Update HammingSerial.h

### DIFF
--- a/HammingSerial.h
+++ b/HammingSerial.h
@@ -43,22 +43,17 @@ bool HammingSerial::readToBuffer() {
   byte b;
   byte in[2];
 
-  if ((readState == PACKET_READ_STATE_END) && _serial->available()) {
-    b = _serial->read();
-    if (b == PACKET_START_SYMBOL) {
-      readState = PACKET_READ_STATE_START;
-    } else {
-      readState = PACKET_READ_STATE_UNKNOWN;
-      ++errorCount;
-      rx_buffer.clear();
-    }
+  if (readState == PACKET_READ_STATE_END) {
+    readState = PACKET_READ_STATE_UNKNOWN;
   }
   
   while ((readState == PACKET_READ_STATE_UNKNOWN) && _serial->available()) {
     b = _serial->read();
     if (b == PACKET_START_SYMBOL) {
       readState = PACKET_READ_STATE_START;
-    } 
+    } else {      
+      ++errorCount;
+    }
   }
   
   if (readState == PACKET_READ_STATE_START) {


### PR DESCRIPTION
After a successful packet is received and HammingSerial.receive() is called, it will continue to return true for as long as no further traffic is on the underlying Serial device.

I beleive this is undesirable behaviour as the HammingSerial.receive() check is called to determine is there is a packet arrived to process. I think the bug is cuased by the following checks in HammingSerial.receive both being conditional on _serial.available() being true.

This saves the user from needing to check that both HammingSerial.receive() is true and that rx_buffer.count is zero